### PR TITLE
Remove Flickr API secret

### DIFF
--- a/assets/js/flickrgal.js
+++ b/assets/js/flickrgal.js
@@ -1,5 +1,4 @@
 var flickrApiKey = '35ca9893a15649318240594ad7dd98e7'; // Change to your flickr api key
-var flickrApiSecret = 'c440757b04345ffe'; // Change to your flickr api secret
 var flickrUserId = '141088533@N02'; // Change to your flickr User ID
 
 // Endpoint url and params


### PR DESCRIPTION
As flickrGal uses Flickr API methods that do not need authorization, API secret is not needed and storing it on client side should be considered very unsafe. This PR removes it.

Ps. Just discovered this plugin. So clean and simple, just what I was looking for! Great job.